### PR TITLE
Add Baudrate for Raspbee2 (RaspBee II)

### DIFF
--- a/tzb-zigpy-cli-tools/CHANGELOG.md
+++ b/tzb-zigpy-cli-tools/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## 0.3.2.0
+- Add baudrate for RaspBee 2 (RaspBee II)
 ## 0.3.1.0
 - Add verbose logging option
 

--- a/tzb-zigpy-cli-tools/DOCS.md
+++ b/tzb-zigpy-cli-tools/DOCS.md
@@ -35,7 +35,7 @@ Pick your radio type from the drop down.
 Pick the Baudrate for your radio, if you don't know it leave it at 115200
 
 # Pick the Zigpy-CLI command to use
-Currently 4 commands are supported from zipy-cli
+Currently 6 commands are supported from zipy-cli
 * **Info** - Read the network information from the radio
 * **Energy Scan** -  Perform an energy scan
 * **Form** - Form a network on a new coordinator
@@ -61,7 +61,7 @@ Add-on configuration:
 | device             | Serial service where the radio is attached |
 | network_device     | Network Serial port (IP_ADDRESS:PORT)
 | radio_type         | Type of radio / coordinator
-| baudrate           | Serial port baudrate (depends on firmware)   |
+| baudrate           | Serial port baudrate (depends on firmware and model)   |
 | action             | zigpy-cli command to run |
 | backup_filename    | Network backup filename |
 

--- a/tzb-zigpy-cli-tools/config.yaml
+++ b/tzb-zigpy-cli-tools/config.yaml
@@ -33,7 +33,7 @@ schema:
   device_type: bool?
   network_device: str?
   radio_type: list(znp|ezsp|deconz|xbee|zigate|zboss)
-  baudrate: list(57600|115200|230400|460800|921600)
+  baudrate: list(38400|57600|115200|230400|460800|921600)
   action: list(info|energy-scan|reset|form|backup|restore)
   backup_filename: str?
   verbose_logging: bool?

--- a/tzb-zigpy-cli-tools/config.yaml
+++ b/tzb-zigpy-cli-tools/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.3.2.0
+version: 0.3.1.0
 slug: tzb-zigpy-cli-tools
 name: TubesZB Zigpy-CLI Tools
 description: TubesZB Zigpy-CLI Toolsadd-on

--- a/tzb-zigpy-cli-tools/config.yaml
+++ b/tzb-zigpy-cli-tools/config.yaml
@@ -1,5 +1,5 @@
 ---
-version: 0.3.1.0
+version: 0.3.2.0
 slug: tzb-zigpy-cli-tools
 name: TubesZB Zigpy-CLI Tools
 description: TubesZB Zigpy-CLI Toolsadd-on


### PR DESCRIPTION
RaspBee II requires a baudrate of 38400, as specified in the Zigbee2MQTT [documentation](https://www.zigbee2mqtt.io/guide/adapters/deconz.html#hardware).

I wanted to change the version, but it breaks the install so hopefully is something you can do it easily.